### PR TITLE
add tiza to the agent finders

### DIFF
--- a/agent-finders.json
+++ b/agent-finders.json
@@ -20,7 +20,7 @@
       "id": "tiza",
       "name": "Tiza",
       "description": "Tiza is a public catalog of MCP servers, A2A agents and skills that agents can query by intent",
-      "search": "https://tiza.cc/search",
+      "search": "https://tiza.cc/api/ard/v1/search",
       "mcp": "https://tiza.cc/mcp"
     }
   ]

--- a/agent-finders.json
+++ b/agent-finders.json
@@ -15,6 +15,13 @@
       "description": "Hugging Face's discovery service for agentic resources.",
       "search": "https://huggingface-hf-discover.hf.space/search",
       "mcp": "https://huggingface-hf-discover.hf.space/mcp"
+    },
+    {
+      "id": "tiza",
+      "name": "Tiza",
+      "description": "Tiza is a public catalog of MCP servers, A2A agents and skills that agents can query by intent",
+      "search": "https://tiza.cc/search",
+      "mcp": "https://tiza.cc/mcp"
     }
   ]
 }


### PR DESCRIPTION
We have been working for some time on finding and curating MCP tools and A2A agents, live-proving them and making them searchable by agents.
When we heard about the ARD protocol, we decided to implement it, so this PR adds the tiza catalog to the seed agent finders.

(more info in comment https://github.com/ards-project/connectors/pull/2#issuecomment-4805916512)